### PR TITLE
fixes scoreboard+signs and clears arena when last player leaves

### DIFF
--- a/src/main/java/pl/plajer/villagedefense/arena/ArenaManager.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/ArenaManager.java
@@ -247,6 +247,7 @@ public class ArenaManager {
     if (arena.getPlayers().isEmpty() && arena.getArenaState() != ArenaState.WAITING_FOR_PLAYERS && arena.getArenaState() != ArenaState.STARTING) {
       arena.setArenaState(ArenaState.ENDING);
       arena.setTimer(0);
+      arena.getMapRestorerManager().fullyRestoreArena();
     }
     ArenaUtils.resetPlayerAfterGame(player);
     arena.teleportToEndLocation(player);

--- a/src/main/java/pl/plajer/villagedefense/handlers/language/LanguageManager.java
+++ b/src/main/java/pl/plajer/villagedefense/handlers/language/LanguageManager.java
@@ -217,7 +217,7 @@ public class LanguageManager {
       list = list.stream().map(string -> ChatColor.translateAlternateColorCodes('&', string)).collect(Collectors.toList());
       return list;
     }
-    return Arrays.asList(path.replace("&", "§").split(";"));
+    return Arrays.asList(prop.replace("&", "§").split(";"));
   }
 
   /**


### PR DESCRIPTION
This fixes two issues we experiences with Village Defense:

1. the scoreboard and signs only show the internal label specifier: this has a rather obvious solution ;)

2. if the last player leaves the arena early (e.g. `/vd leave` or disconnect from server), mobs are not cleared and will still be there when the next game starts. They don't count as game mobs, but leftover zombies and golems will still attack mobs belonging to the game. 
I'm not deep enough in your code to be sure that my solution is the best option, but at least it works. 

Would be nice of those make it into the next release :)