### PR TITLE
door break listener should only scan village defense worlds

### DIFF
--- a/src/main/java/pl/plajer/villagedefense/Main.java
+++ b/src/main/java/pl/plajer/villagedefense/Main.java
@@ -48,7 +48,6 @@ import pl.plajer.villagedefense.arena.ArenaUtils;
 import pl.plajer.villagedefense.arena.managers.BungeeManager;
 import pl.plajer.villagedefense.commands.arguments.ArgumentsRegistry;
 import pl.plajer.villagedefense.creatures.CreatureUtils;
-import pl.plajer.villagedefense.creatures.DoorBreakListener;
 import pl.plajer.villagedefense.creatures.EntityRegistry;
 import pl.plajer.villagedefense.events.ChatEvents;
 import pl.plajer.villagedefense.events.Events;
@@ -299,7 +298,6 @@ public class Main extends JavaPlugin {
       new EntityUpgradeMenu(this);
     }
     userManager = new UserManager(this);
-    new DoorBreakListener(this);
 
     ArenaRegistry.registerArenas();
     //we must start it after instances load!

--- a/src/main/java/pl/plajer/villagedefense/arena/ArenaUtils.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/ArenaUtils.java
@@ -18,6 +18,9 @@
 
 package pl.plajer.villagedefense.arena;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.bukkit.GameMode;
 import org.bukkit.Particle;
 import org.bukkit.attribute.Attribute;
@@ -25,6 +28,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Zombie;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitTask;
 
 import pl.plajer.villagedefense.ConfigPreferences;
 import pl.plajer.villagedefense.Main;
@@ -35,6 +39,7 @@ import pl.plajer.villagedefense.arena.initializers.ArenaInitializer1_13_R1;
 import pl.plajer.villagedefense.arena.initializers.ArenaInitializer1_13_R2;
 import pl.plajer.villagedefense.arena.initializers.ArenaInitializer1_14_R1;
 import pl.plajer.villagedefense.arena.initializers.ArenaInitializer1_15_R1;
+import pl.plajer.villagedefense.creatures.DoorBreakListener;
 import pl.plajer.villagedefense.handlers.PermissionsManager;
 import pl.plajer.villagedefense.handlers.language.Messages;
 import pl.plajer.villagedefense.user.User;
@@ -48,6 +53,7 @@ import pl.plajerlair.commonsbox.minecraft.serialization.InventorySerializer;
 public class ArenaUtils {
 
   private static Main plugin;
+  private static Map<String, BukkitTask> taskMap = new HashMap<String, BukkitTask>();
 
   private ArenaUtils() {
   }
@@ -193,4 +199,16 @@ public class ArenaUtils {
     }
   }
 
+  public static void startDoorBreakListener(Arena arena) {
+	  BukkitTask doorBreakTask = new DoorBreakListener(plugin, arena).runTaskTimer(plugin, 1, 20);
+	  taskMap.put(arena.getId(), doorBreakTask);
+  }
+
+  public static void stopDoorBreakListener(Arena arena) {
+	  if (!taskMap.containsKey(arena.getId())) {
+		  return;
+	  }
+	  taskMap.get(arena.getId()).cancel();
+	  taskMap.remove(arena.getId());
+  }
 }

--- a/src/main/java/pl/plajer/villagedefense/arena/states/EndingState.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/states/EndingState.java
@@ -63,6 +63,7 @@ public class EndingState implements ArenaStateHandler {
       plugin.getRewardsHandler().performReward(arena, Reward.RewardType.END_GAME);
       arena.setArenaState(ArenaState.RESTARTING);
     }
+    ArenaUtils.stopDoorBreakListener(arena);
     arena.setTimer(arena.getTimer() - 1);
   }
 

--- a/src/main/java/pl/plajer/villagedefense/arena/states/StartingState.java
+++ b/src/main/java/pl/plajer/villagedefense/arena/states/StartingState.java
@@ -86,6 +86,7 @@ public class StartingState implements ArenaStateHandler {
         player.sendMessage(plugin.getChatManager().getPrefix() + plugin.getChatManager().colorMessage(Messages.LOBBY_MESSAGES_GAME_STARTED));
       }
       arena.setFighting(false);
+      ArenaUtils.startDoorBreakListener(arena);
     }
     if (arena.isForceStart()) {
       arena.setForceStart(false);

--- a/src/main/java/pl/plajer/villagedefense/creatures/DoorBreakListener.java
+++ b/src/main/java/pl/plajer/villagedefense/creatures/DoorBreakListener.java
@@ -18,9 +18,10 @@
 
 package pl.plajer.villagedefense.creatures;
 
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
@@ -31,6 +32,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import pl.plajer.villagedefense.Main;
+import pl.plajer.villagedefense.arena.Arena;
+import pl.plajer.villagedefense.arena.ArenaRegistry;
 import pl.plajer.villagedefense.utils.Utils;
 import pl.plajer.villagedefense.utils.constants.CompatMaterialConstants;
 import pl.plajerlair.commonsbox.minecraft.compat.XMaterial;
@@ -50,7 +53,7 @@ public class DoorBreakListener extends BukkitRunnable {
 
   @Override
   public void run() {
-    for (World world : Bukkit.getServer().getWorlds()) {
+    for (World world : getWorlds()) {
       for (LivingEntity entity : world.getLivingEntities()) {
         if (entity.getType() != EntityType.ZOMBIE) {
           continue;
@@ -85,4 +88,11 @@ public class DoorBreakListener extends BukkitRunnable {
     }
   }
 
+  private Set<World> getWorlds() {
+    Set<World> worlds = new HashSet<>();
+    for (Arena arena : ArenaRegistry.getArenas()) {
+      worlds.add(arena.getStartLocation().getWorld());
+    }
+    return worlds;
+  }
 }


### PR DESCRIPTION
The door break listener constantly scans every loaded world on the server, checking every living entity, even if there are no players playing Village_Defense. This is unnecessary and can put extra burden on survival/skyblock worlds that may contain many entities. 

This PR creates a list of unique world names that contain Village_Defense arenas, and then only scans those worlds.

Tested successfully on 1.15.2.
This is as per the ticket raised on Discord #vd-steve4744.