### PR TITLE
revert "Updated inventory framework"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>com.github.stefvanschie.inventoryframework</groupId>
             <artifactId>IF</artifactId>
-            <version>0.9.5</version>
+            <version>0.5.19</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
@@ -18,8 +18,8 @@
 
 package plugily.projects.villagedefense.arena.managers;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -61,7 +61,7 @@ public class ShopManager {
 
   private final Main plugin;
   private final FileConfiguration config;
-  private ChestGui gui;
+  private Gui gui;
   private final Arena arena;
 
   public ShopManager(Arena arena) {
@@ -76,7 +76,7 @@ public class ShopManager {
     }
   }
 
-  public ChestGui getShop() {
+  public Gui getShop() {
     return gui;
   }
 
@@ -117,7 +117,7 @@ public class ShopManager {
     ItemStack[] contents = ((Chest) LocationSerializer.getLocation(config.getString("instances." + arena.getId() + ".shop"))
         .getBlock().getState()).getInventory().getContents();
     int size = Utils.serializeInt(contents.length) / 9;
-    ChestGui gui = new ChestGui(size, plugin.getChatManager().colorMessage(Messages.SHOP_MESSAGES_SHOP_GUI_NAME));
+    Gui gui = new Gui(plugin, size, plugin.getChatManager().colorMessage(Messages.SHOP_MESSAGES_SHOP_GUI_NAME));
     StaticPane pane = new StaticPane(9, size);
     int x = 0;
     int y = 0;

--- a/src/main/java/plugily/projects/villagedefense/events/spectator/SpectatorItemEvents.java
+++ b/src/main/java/plugily/projects/villagedefense/events/spectator/SpectatorItemEvents.java
@@ -18,8 +18,8 @@
 
 package plugily.projects.villagedefense.events.spectator;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.OutlinePane;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -81,7 +81,7 @@ public class SpectatorItemEvents implements Listener {
 
   private void openSpectatorMenu(World world, Player player, Arena arena) {
     int rows = Utils.serializeInt(arena.getPlayers().size()) / 9;
-    ChestGui gui = new ChestGui(rows, plugin.getChatManager().colorMessage(Messages.SPECTATOR_MENU_NAME));
+    Gui gui = new Gui(plugin, rows, plugin.getChatManager().colorMessage(Messages.SPECTATOR_MENU_NAME));
     OutlinePane pane = new OutlinePane(9, rows);
     gui.addPane(pane);
 

--- a/src/main/java/plugily/projects/villagedefense/handlers/setup/SetupInventory.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/setup/SetupInventory.java
@@ -18,7 +18,7 @@
 
 package plugily.projects.villagedefense.handlers.setup;
 
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -44,7 +44,7 @@ public class SetupInventory {
   private final FileConfiguration config;
   private final Arena arena;
   private final Player player;
-  private ChestGui gui;
+  private Gui gui;
   private final SetupUtilities setupUtilities;
 
   public SetupInventory(Arena arena, Player player) {
@@ -60,7 +60,7 @@ public class SetupInventory {
   }
 
   private void prepareGui() {
-    gui = new ChestGui(2, "Village Defense Arena Setup");
+    gui = new Gui(plugin, 2, "Village Defense Arena Setup");
     gui.setOnGlobalClick(e -> e.setCancelled(true));
     StaticPane pane = new StaticPane(9, 4);
     gui.addPane(pane);
@@ -141,7 +141,7 @@ public class SetupInventory {
     return player;
   }
 
-  public ChestGui getGui() {
+  public Gui getGui() {
     return gui;
   }
 

--- a/src/main/java/plugily/projects/villagedefense/handlers/setup/components/ArenaRegisterComponent.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/setup/components/ArenaRegisterComponent.java
@@ -18,7 +18,7 @@
 
 package plugily.projects.villagedefense.handlers.setup.components;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
+import com.github.stefvanschie.inventoryframework.GuiItem;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/main/java/plugily/projects/villagedefense/handlers/setup/components/MiscComponents.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/setup/components/MiscComponents.java
@@ -18,7 +18,7 @@
 
 package plugily.projects.villagedefense.handlers.setup.components;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
+import com.github.stefvanschie.inventoryframework.GuiItem;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/main/java/plugily/projects/villagedefense/handlers/setup/components/PlayerAmountComponents.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/setup/components/PlayerAmountComponents.java
@@ -18,7 +18,7 @@
 
 package plugily.projects.villagedefense.handlers.setup.components;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
+import com.github.stefvanschie.inventoryframework.GuiItem;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/plugily/projects/villagedefense/handlers/setup/components/SpawnComponents.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/setup/components/SpawnComponents.java
@@ -18,7 +18,7 @@
 
 package plugily.projects.villagedefense.handlers.setup.components;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
+import com.github.stefvanschie.inventoryframework.GuiItem;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/plugily/projects/villagedefense/handlers/upgrade/EntityUpgradeMenu.java
+++ b/src/main/java/plugily/projects/villagedefense/handlers/upgrade/EntityUpgradeMenu.java
@@ -18,8 +18,8 @@
 
 package plugily.projects.villagedefense.handlers.upgrade;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import net.minecraft.server.v1_8_R3.AttributeInstance;
 import net.minecraft.server.v1_8_R3.AttributeModifier;
@@ -131,7 +131,7 @@ public class EntityUpgradeMenu {
    * @param player player who will see inventory
    */
   public void openUpgradeMenu(LivingEntity en, Player player) {
-    ChestGui gui = new ChestGui(6, color(Messages.UPGRADES_MENU_TITLE));
+    Gui gui = new Gui(plugin, 6, color(Messages.UPGRADES_MENU_TITLE));
     StaticPane pane = new StaticPane(9, 6);
     User user = plugin.getUserManager().getUser(player);
 

--- a/src/main/java/plugily/projects/villagedefense/kits/KitMenuHandler.java
+++ b/src/main/java/plugily/projects/villagedefense/kits/KitMenuHandler.java
@@ -18,8 +18,8 @@
 
 package plugily.projects.villagedefense.kits;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -62,7 +62,7 @@ public class KitMenuHandler implements Listener {
   }
 
   public void createMenu(Player player) {
-    ChestGui gui = new ChestGui(Utils.serializeInt(KitRegistry.getKits().size()) / 9, plugin.getChatManager().colorMessage(Messages.KITS_OPEN_KIT_MENU));
+    Gui gui = new Gui(plugin, Utils.serializeInt(KitRegistry.getKits().size()) / 9, plugin.getChatManager().colorMessage(Messages.KITS_OPEN_KIT_MENU));
     StaticPane pane = new StaticPane(9, gui.getRows());
     gui.addPane(pane);
     int x = 0;

--- a/src/main/java/plugily/projects/villagedefense/kits/premium/TeleporterKit.java
+++ b/src/main/java/plugily/projects/villagedefense/kits/premium/TeleporterKit.java
@@ -18,8 +18,8 @@
 
 package plugily.projects.villagedefense.kits.premium;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.Gui;
 import com.github.stefvanschie.inventoryframework.pane.OutlinePane;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -115,7 +115,7 @@ public class TeleporterKit extends PremiumKit implements Listener {
   }
 
   private void prepareTeleporterGui(Player player, Arena arena, int rows) {
-    ChestGui gui = new ChestGui(rows, getPlugin().getChatManager().colorMessage(Messages.KITS_TELEPORTER_GAME_ITEM_MENU_NAME));
+    Gui gui = new Gui(getPlugin(), rows, getPlugin().getChatManager().colorMessage(Messages.KITS_TELEPORTER_GAME_ITEM_MENU_NAME));
     gui.setOnGlobalClick(onClick -> onClick.setCancelled(true));
     OutlinePane pane = new OutlinePane(9, rows);
     gui.addPane(pane);


### PR DESCRIPTION
The latest version of IF only supports 1.14 and above.
The reason is that those versions have `PersistentDataType`, which IF is using.
Versions prior to 1.14 will receive an `NoClassDefFoundError`.

If you have a plan to drop those versions, ignore and close this PR.