### PR TITLE
Don't check the config when checking permanent spectator

### DIFF
--- a/src/main/java/plugily/projects/villagedefense/arena/ArenaUtils.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/ArenaUtils.java
@@ -99,7 +99,7 @@ public class ArenaUtils {
       }
 
       User user = plugin.getUserManager().getUser(player);
-      if(!plugin.getConfigPreferences().getOption(ConfigPreferences.Option.INGAME_JOIN_RESPAWN) && user.isPermanentSpectator()) {
+      if(user.isPermanentSpectator()) {
         continue;
       }
       user.setSpectator(false);


### PR DESCRIPTION
This will allow for some super spectators, those who won't respawn on wave end.