### PR TITLE
remove raw color codes in shop cost (Commons-Box issue in latest commit)

### DIFF
--- a/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
@@ -48,6 +48,7 @@ import plugily.projects.villagedefense.utils.Utils;
 import plugily.projects.villagedefense.utils.constants.Constants;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -136,7 +137,7 @@ public class ShopManager {
       if(itemStack.hasItemMeta() && itemStack.getItemMeta().hasLore()) {
         for(String s : ComplementAccessor.getComplement().getLore(itemStack.getItemMeta())) {
           if(s.contains(plugin.getChatManager().colorMessage(Messages.SHOP_MESSAGES_CURRENCY_IN_SHOP)) || s.contains("orbs")) {
-            costString = ChatColor.stripColor(s).replaceAll("[^0-9]", "");
+            costString = ChatColor.stripColor(s).replaceAll("&[0-9a-zA-Z]", "").replaceAll("[^0-9]", "");
             break;
           }
         }

--- a/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
@@ -48,7 +48,6 @@ import plugily.projects.villagedefense.utils.Utils;
 import plugily.projects.villagedefense.utils.constants.Constants;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
`legacyAmpersand()`'s `getLore` will serialize the lore with the color codes.
Therefore, the return lore will be something like `&650 orbs` and will then be reduced to `650`.