### PR TITLE
fix spawner comparator & FastZombie spawner for the last

### DIFF
--- a/src/main/java/plugily/projects/villagedefense/arena/managers/spawner/FastZombieSpawner.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/spawner/FastZombieSpawner.java
@@ -43,4 +43,9 @@ public class FastZombieSpawner implements SimpleZombieSpawner {
   public String getName() {
     return "FastZombie";
   }
+
+  @Override
+  public int getPriority() {
+    return -1;
+  }
 }

--- a/src/main/java/plugily/projects/villagedefense/arena/managers/spawner/ZombieSpawner.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/spawner/ZombieSpawner.java
@@ -32,6 +32,10 @@ public interface ZombieSpawner extends Comparable<ZombieSpawner> {
 
   @Override
   default int compareTo(ZombieSpawner spawner) {
-    return Integer.compare(this.getPriority(), spawner.getPriority());
+    int compareValue = Integer.compare(this.getPriority(), spawner.getPriority());
+    if (compareValue == 0) {
+      compareValue = this.getName().compareTo(spawner.getName());
+    }
+    return compareValue;
   }
 }


### PR DESCRIPTION
Now it will compare the name of the spawner if the priority is the same (fix the bug when 2 spawners with the same priority don't add to the set together)
And set the priority of the FastZombie spawner so it will be the last one to check every loop