### PR TITLE
fix duplicated dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,13 +196,6 @@
         </dependency>
         <dependency>
             <groupId>plugily.projects</groupId>
-            <artifactId>MiniGamesBox-Inventory</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>plugily.projects</groupId>
             <artifactId>MiniGamesBox-Classic</artifactId>
             <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>

--- a/src/main/java/plugily/projects/villagedefense/Main.java
+++ b/src/main/java/plugily/projects/villagedefense/Main.java
@@ -18,7 +18,6 @@
 
 package plugily.projects.villagedefense;
 
-import fr.mrmicky.fastinv.FastInvManager;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
@@ -143,7 +142,6 @@ public class Main extends PluginMain {
     new DoorBreakListener(this);
     CreatureUtils.init(this);
     addPluginMetrics();
-    FastInvManager.register(this);
   }
 
   public void addAdditionalValues() {


### PR DESCRIPTION
We already shade Inventory into Classic, so we don't have to explicitly include that here.