### PR TITLE
Fix color code translation for shop.

### DIFF
--- a/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
+++ b/src/main/java/plugily/projects/villagedefense/arena/managers/ShopManager.java
@@ -136,6 +136,7 @@ public class ShopManager {
         String currency = ChatColor.stripColor(new MessageBuilder("IN_GAME_MESSAGES_VILLAGE_SHOP_CURRENCY").asKey().build());
         for(String s : ComplementAccessor.getComplement().getLore(meta)) {
           if(s.contains(currency) || s.contains("orbs")) {
+            costString = ChatColor.translateAlternateColorCodes('&', s);
             costString = ChatColor.stripColor(s).replace(currency, "").replace("orbs", "").trim();
             break;
           }


### PR DESCRIPTION
the ChatColor.stripColor only strips § prefix so i've added a & to § translation for the meta.. this should fix the shop not being loaded if the unicode changes ( which it did )